### PR TITLE
Equation in Markdown

### DIFF
--- a/ChapterOne/README.md
+++ b/ChapterOne/README.md
@@ -17,4 +17,4 @@ Root is a modular scirntific sofeware framwork.It provides all kinds of function
 There are many useful packages and headfiles in ROOT.It's itself a powerful calculation tools,and some packages useful to me to analyze deviation and plot.After including the headfiles,what I need to do is to create a canva and plotted on it!
 
 ###Realization
-1.Cutting off from Taylor Expansion is the core of Euler method.![](http://latex.codecogs.com/gif.latex?\N_U($Delta$t)=N_U(0)+\frac{dN_U}{dt}$Delta$t+\frac{1}{2}frac\{d^2N_U}{dt^2}($Deltat$)^2+...)
+1.Cutting off from Taylor Expansion is the core of Euler method.![](http://latex.codecogs.com/gif.latex?\N_U(\\Delta\ t)=N_U(0)+\\frac{dN_U}{dt}\\Delta\ t+\\frac{1}{2}frac\\{d^2N_U}{dt^2}(\\Delta\ t)^2+\\cdots)

--- a/ChapterOne/README.md
+++ b/ChapterOne/README.md
@@ -17,4 +17,4 @@ Root is a modular scirntific sofeware framwork.It provides all kinds of function
 There are many useful packages and headfiles in ROOT.It's itself a powerful calculation tools,and some packages useful to me to analyze deviation and plot.After including the headfiles,what I need to do is to create a canva and plotted on it!
 
 ###Realization
-1.Cutting off from Taylor Expansion is the core of Euler method.![](http://latex.codecogs.com/gif.latex?\N_U(\\Delta\ t)=N_U(0)+\\frac{dN_U}{dt}\\Delta\ t+\\frac{1}{2}frac\\{d^2N_U}{dt^2}(\\Delta\ t)^2+\\cdots)
+1.Cutting off from Taylor Expansion is the core of Euler method.![](http://latex.codecogs.com/gif.latex?N_U(\\Delta\ t)=N_U(0)+\\frac{dN_U}{dt}\\Delta\ t+\\frac{1}{2}frac\\{d^2N_U}{dt^2}(\\Delta\ t)^2+\\cdots)

--- a/ChapterOne/README.md
+++ b/ChapterOne/README.md
@@ -17,4 +17,4 @@ Root is a modular scirntific sofeware framwork.It provides all kinds of function
 There are many useful packages and headfiles in ROOT.It's itself a powerful calculation tools,and some packages useful to me to analyze deviation and plot.After including the headfiles,what I need to do is to create a canva and plotted on it!
 
 ###Realization
-1.Cutting off from Taylor Expansion is the core of Euler method.![](http://latex.codecogs.com/gif.latex?N_U(\\Delta\ t)=N_U(0)+\\frac{dN_U}{dt}\\Delta\ t+\\frac{1}{2}frac\\{d^2N_U}{dt^2}(\\Delta\ t)^2+\\cdots)
+1.Cutting off from Taylor Expansion is the core of Euler method.![eqn](http://latex.codecogs.com/gif.latex?N_U(\\Delta\ t)=N_U(0)+\\frac{dN_U}{dt}\\Delta\ t+\\frac{1}{2}\\frac{d^2N_U}{dt^2}(\\Delta\ t)^2+\\cdots)


### PR DESCRIPTION
1. the API provided by the website already assumed you to be in equaiton environment, so `$` is redundant.
2. be mindful about `\` as in it is supposed to be escaping character in markdown format. Or if you use Vim, you can try [my plugin](https://github.com/Ron89/md_insert_equation.vim). With formatting stuff already taken care of, you can write pure `LaTeX` equation with the help of it.
